### PR TITLE
nuxt generateで生成されたjsファイル及び、イメージファイルに対してCache-Control: max-age=31536000(365日分の秒数)を指定する

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -11,6 +11,22 @@
         "source": "**",
         "destination": "/index.html"
       }
+    ],
+    "headers": [
+      {
+        "source": "**/*.@(jpg|jpeg|gif|png|svg)",
+        "headers": [{
+          "key": "Cache-Control",
+          "value": "max-age=31536000"
+        }]
+      },
+      {
+        "source": "_nuxt/*.js",
+        "headers": [{
+          "key": "Cache-Control",
+          "value": "max-age=31536000"
+        }]
+      }
     ]
   }
 }


### PR DESCRIPTION
## 概要
nuxt generateで生成されたjsファイル及び、イメージファイルに対して
Cache-Control: max-age=31536000(365日分の秒数)を指定する

Firebase HostingのHTTP Headersの設定に関する記事:
https://firebase.google.com/docs/hosting/full-config?hl=ja#headers

キャッシュの設定の参考にした記事:
https://zenn.dev/thetalemon/articles/d501197b08dfa2