### PR TITLE
GoogleAdsenseの広告を各箇所に表示する

### DIFF
--- a/components/atoms/GoogleAdsenseDisplayAd.vue
+++ b/components/atoms/GoogleAdsenseDisplayAd.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2278159842551677"
+crossorigin="anonymous"></script>
+    <!-- ディスプレイ広告_レスポンシブ -->
+    <ins class="adsbygoogle"
+         style="display:block"
+         data-ad-client="ca-pub-2278159842551677"
+         data-ad-slot="3269242422"
+         data-ad-format="auto"
+         data-full-width-responsive="true"></ins>
+    <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
+  </div>
+</template>

--- a/components/atoms/GoogleAdsenseInfeedAd.vue
+++ b/components/atoms/GoogleAdsenseInfeedAd.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2278159842551677"
+crossorigin="anonymous"></script>
+    <ins class="adsbygoogle"
+         style="display:block"
+         data-ad-format="fluid"
+         data-ad-layout-key="-fb+5w+4e-db+86"
+         data-ad-client="ca-pub-2278159842551677"
+         data-ad-slot="5405872058"></ins>
+    <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
+  </div>
+</template>

--- a/components/atoms/GoogleAdsenseMultiplexAd.vue
+++ b/components/atoms/GoogleAdsenseMultiplexAd.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2278159842551677"
+crossorigin="anonymous"></script>
+    <ins class="adsbygoogle"
+         style="display:block"
+         data-ad-format="autorelaxed"
+         data-ad-client="ca-pub-2278159842551677"
+         data-ad-slot="2173204058"></ins>
+    <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
+  </div>
+</template>

--- a/components/organisms/MagazineImages.vue
+++ b/components/organisms/MagazineImages.vue
@@ -9,9 +9,12 @@
     />
 
     <ul class="magazine-images">
-      <li v-for="image in imageList" class="magazine-image">
+      <!-- NOTE: indexは0からスタート -->
+      <li v-for="(image, index) in imageList" class="magazine-image">
         <h3 class="magazine-image__title">{{ image.story_number }}話</h3>
         <img class="magazine-image__image" :src="image.src">
+        <!-- NOTE: 2話ごとに広告を挿入 -->
+        <GoogleAdsenseInfeedAd v-if="index % 2 == 1"/>
       </li>
     </ul>
 

--- a/components/organisms/layout/Sidebar.vue
+++ b/components/organisms/layout/Sidebar.vue
@@ -2,6 +2,8 @@
   <aside class="sidebar">
     <ProfileCard />
 
+    <GoogleAdsenseMultiplexAd />
+
     <TwitterTimeline />
   </aside>
 </template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="wrapper">
+    <GoogleAdsenseDisplayAd />
+
     <LayoutHeader />
     <LayoutInformation />
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -6,6 +6,8 @@
     <div class="main">
       <div class="main__body">
         <Nuxt />
+
+        <GoogleAdsenseInfeedAd />
       </div>
 
       <div class="main__sidebar">


### PR DESCRIPTION
## 概要
[Google Adsense](https://www.google.com/adsense/signup?hl=ja) に登録して、各広告のタグを配置した

## 変更内容
* [bodyタグ内のメインコンテンツの下部、漫画を2話表示するごとにGoogleAdsenseのインフィード広告を表示する](https://github.com/BayaSea0907/hokuro-books/commit/d4a12025e3fb37c41ec0dc266d194077126f81e4)
* [GoogleAdsenseのディスプレイ広告を追加する](https://github.com/BayaSea0907/hokuro-books/commit/dac8414bc4c7bf1894e503c0065ab670a7d641b2)
* [サイドバーにGoogleAdsenseのMultipleAd広告を表示する](https://github.com/BayaSea0907/hokuro-books/commit/14f17c74ca64686effd89ea0e212d8bfdec757ff)